### PR TITLE
Remove aiodns from extras_require

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -89,7 +89,6 @@ setup(
     extras_require={
         ':python_version>="3.5.2"': [
             'aiohttp>=3.10.11',
-            'aiodns>=1.1.1',
             'yarl>=1.7.2',
         ],
         ':python_version>="3.9"': [


### PR DESCRIPTION
Removed aiodns from extras_require for Python 3.5.2

https://github.com/ccxt/ccxt/issues/18971
https://github.com/ccxt/ccxt/pull/27129