### PR TITLE
Remove coincurve dependency for Python 3.9

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -91,9 +91,6 @@ setup(
             'aiohttp>=3.10.11',
             'yarl>=1.7.2',
         ],
-        ':python_version>="3.9"': [
-            'coincurve==20.0.0',
-        ],
         'qa': [
             'ruff==0.0.292',
             'tox>=4.8.0',


### PR DESCRIPTION
#### ECDSA Support

Some exchanges, such as Hyperliquid, Binance, and Paradex use **ECDSA** for request signing. By default, CCXT includes a pure Python ECDSA implementation that ensures compatibility across all environments. However, this implementation may not meet the performance requirements of latency-sensitive applications.

To address this, CCXT also supports the Coincurve library, which dramatically reduces signing time from approximately 45 ms to under 0.05 ms.

For optimal performance, we recommend installing Coincurve via:

```
pip install coincurve
```

Once installed, CCXT will automatically detect and use it.